### PR TITLE
Support block duration spot instance

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -242,6 +242,7 @@ class EC2Cluster(FlintrockCluster):
             identity_file: str,
             instance_type: str,
             block_duration_minutes: int,
+            guarantee_num_instance: bool,
             num_slaves: int,
             spot_price: float,
             min_root_ebs_size_gb: int,
@@ -290,6 +291,7 @@ class EC2Cluster(FlintrockCluster):
                 key_name=self.master_instance.key_name,
                 instance_type=instance_type,
                 block_duration_minutes=block_duration_minutes,
+                guarantee_num_instance=guarantee_num_instance,
                 block_device_mappings=block_device_mappings,
                 availability_zone=availability_zone,
                 placement_group=self.master_instance.placement['GroupName'],
@@ -689,6 +691,7 @@ def _create_instances(
         key_name,
         instance_type,
         block_duration_minutes,
+        guarantee_num_instance,
         block_device_mappings,
         availability_zone,
         placement_group,
@@ -736,10 +739,12 @@ def _create_instances(
             request_ids = [r['SpotInstanceRequestId'] for r in spot_requests]
             pending_request_ids = request_ids
 
-            while pending_request_ids:
+            # Cancel Open spot request, and displace remaining request with on demand request.
+            if guarantee_num_instance and block_duration_minutes:
                 logger.info("{grant} of {req} instances granted. Waiting...".format(
                     grant=num_instances - len(pending_request_ids),
                     req=num_instances))
+                # waiting for spot reqeusts are fully processed
                 time.sleep(30)
                 spot_requests = client.describe_spot_instance_requests(
                     SpotInstanceRequestIds=request_ids)['SpotInstanceRequests']
@@ -752,18 +757,75 @@ def _create_instances(
                         .format(
                             s='' if len(failure_reasons) == 1 else 's',
                             reasons=', '.join(failure_reasons)))
-
                 pending_request_ids = [
                     r['SpotInstanceRequestId'] for r in spot_requests
                     if r['State'] == 'open']
 
+                logger.info("{grant} of {req} instances granted. Waiting...".format(
+                    grant=num_instances - len(pending_request_ids),
+                    req=num_instances))
+
+                remaining_num_instances = len(pending_request_ids)
+                block_cluster_instances = list(
+                    ec2.instances.filter(
+                        Filters=[
+                            {'Name': 'instance-id', 'Values': [r.get('InstanceId', '') for r in spot_requests]}
+                        ]))
+                demand_cluster_instances = list()
+
+                if remaining_num_instances > 0:
+                    client.cancel_spot_instance_requests(
+                        SpotInstanceRequestIds=pending_request_ids)
+                    logger.info("cancel success, launch {} on-demand instances".format(len(pending_request_ids)))
+                    demand_cluster_instances = ec2.create_instances(
+                        MinCount=remaining_num_instances,
+                        MaxCount=remaining_num_instances,
+                        ImageId=ami,
+                        KeyName=key_name,
+                        InstanceType=instance_type,
+                        BlockDeviceMappings=block_device_mappings,
+                        Placement={
+                            'AvailabilityZone': availability_zone,
+                            'Tenancy': tenancy,
+                            'GroupName': placement_group},
+                        SecurityGroupIds=security_group_ids,
+                        SubnetId=subnet_id,
+                        IamInstanceProfile={
+                            'Arn': instance_profile_arn},
+                        EbsOptimized=ebs_optimized,
+                        InstanceInitiatedShutdownBehavior=instance_initiated_shutdown_behavior,
+                        UserData=user_data)
+                cluster_instances = block_cluster_instances + demand_cluster_instances
+            else:
+                while pending_request_ids:
+                    logger.info("{grant} of {req} instances granted. Waiting...".format(
+                        grant=num_instances - len(pending_request_ids),
+                        req=num_instances))
+
+                    time.sleep(30)
+                    spot_requests = client.describe_spot_instance_requests(
+                        SpotInstanceRequestIds=request_ids)['SpotInstanceRequests']
+
+                    failed_requests = [r for r in spot_requests if r['State'] == 'failed']
+                    if failed_requests:
+                        failure_reasons = {r['Status']['Code'] for r in failed_requests}
+                        raise Error(
+                            "The spot request failed for the following reason{s}: {reasons}"
+                            .format(
+                                s='' if len(failure_reasons) == 1 else 's',
+                                reasons=', '.join(failure_reasons)))
+
+                    pending_request_ids = [
+                        r['SpotInstanceRequestId'] for r in spot_requests
+                        if r['State'] == 'open']
+
+                cluster_instances = list(
+                    ec2.instances.filter(
+                        Filters=[
+                            {'Name': 'instance-id', 'Values': [r['InstanceId'] for r in spot_requests]}
+                        ]))
             logger.info("All {c} instances granted.".format(c=num_instances))
 
-            cluster_instances = list(
-                ec2.instances.filter(
-                    Filters=[
-                        {'Name': 'instance-id', 'Values': [r['InstanceId'] for r in spot_requests]}
-                    ]))
         else:
             # Move this to flintrock.py?
             logger.info("Launching {c} instance{s}...".format(
@@ -827,6 +889,7 @@ def launch(
         identity_file,
         instance_type,
         block_duration_minutes,
+        guarantee_num_instance,
         region,
         availability_zone,
         ami,
@@ -912,6 +975,7 @@ def launch(
             instance_type=instance_type,
             block_duration_minutes=block_duration_minutes,
             block_device_mappings=block_device_mappings,
+            guarantee_num_instance=guarantee_num_instance,
             availability_zone=availability_zone,
             placement_group=placement_group,
             tenancy=tenancy,

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -289,6 +289,10 @@ def cli(cli_context, config, provider, debug):
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-instance-type', default='m3.medium', show_default=True)
 @click.option('--ec2-block-duration-minutes', type=int, default=0)
+@click.option('--ec2-guarantee-num-instance',
+              help="Guarantee number of instance for block-defined spot instance. "
+                   "If spot requests are pending, it cancel all open requests and create on-demand instance.",
+              is_flag=True, default=False)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 # We set some of these defaults to empty strings because of boto3's parameter validation.
 # See: https://github.com/boto/boto3/issues/400
@@ -336,6 +340,7 @@ def launch(
         ec2_identity_file,
         ec2_instance_type,
         ec2_block_duration_minutes,
+        ec2_guarantee_num_instance,
         ec2_region,
         ec2_availability_zone,
         ec2_ami,
@@ -441,6 +446,7 @@ def launch(
             identity_file=ec2_identity_file,
             instance_type=ec2_instance_type,
             block_duration_minutes=ec2_block_duration_minutes,
+            guarantee_num_instance=ec2_guarantee_num_instance,
             region=ec2_region,
             availability_zone=ec2_availability_zone,
             ami=ec2_ami,
@@ -721,6 +727,10 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-instance-type', default='m3.medium', show_default=True)
 @click.option('--ec2-block-duration-minutes', type=int, default=0)
+@click.option('--ec2-guarantee-num-instance',
+              help="Guarantee number of instance for block-defined spot instance. "
+                   "If spot requests are pending, it cancel all open requests and create on-demand instance.",
+              is_flag=True, default=False)
 @click.option('--ec2-user')
 @click.option('--ec2-spot-price', type=float)
 @click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
@@ -740,6 +750,7 @@ def add_slaves(
         ec2_identity_file,
         ec2_instance_type,
         ec2_block_duration_minutes,
+        ec2_guarantee_num_instance,
         ec2_user,
         ec2_spot_price,
         ec2_min_root_ebs_size_gb,
@@ -795,6 +806,7 @@ def add_slaves(
             identity_file=identity_file,
             instance_type=ec2_instance_type,
             block_duration_minutes=ec2_block_duration_minutes,
+            guarantee_num_instance=ec2_guarantee_num_instance,
             num_slaves=num_slaves,
             assume_yes=assume_yes,
             **provider_options)

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -288,6 +288,7 @@ def cli(cli_context, config, provider, debug):
               type=click.Path(exists=True, dir_okay=False),
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-instance-type', default='m3.medium', show_default=True)
+@click.option('--ec2-block-duration-minutes', type=int, default=0)
 @click.option('--ec2-region', default='us-east-1', show_default=True)
 # We set some of these defaults to empty strings because of boto3's parameter validation.
 # See: https://github.com/boto/boto3/issues/400
@@ -334,6 +335,7 @@ def launch(
         ec2_key_name,
         ec2_identity_file,
         ec2_instance_type,
+        ec2_block_duration_minutes,
         ec2_region,
         ec2_availability_zone,
         ec2_ami,
@@ -438,6 +440,7 @@ def launch(
             key_name=ec2_key_name,
             identity_file=ec2_identity_file,
             instance_type=ec2_instance_type,
+            block_duration_minutes=ec2_block_duration_minutes,
             region=ec2_region,
             availability_zone=ec2_availability_zone,
             ami=ec2_ami,
@@ -717,6 +720,7 @@ def stop(cli_context, cluster_name, ec2_region, ec2_vpc_id, assume_yes):
               type=click.Path(exists=True, dir_okay=False),
               help="Path to SSH .pem file for accessing nodes.")
 @click.option('--ec2-instance-type', default='m3.medium', show_default=True)
+@click.option('--ec2-block-duration-minutes', type=int, default=0)
 @click.option('--ec2-user')
 @click.option('--ec2-spot-price', type=float)
 @click.option('--ec2-min-root-ebs-size-gb', type=int, default=30)
@@ -735,6 +739,7 @@ def add_slaves(
         ec2_vpc_id,
         ec2_identity_file,
         ec2_instance_type,
+        ec2_block_duration_minutes,
         ec2_user,
         ec2_spot_price,
         ec2_min_root_ebs_size_gb,
@@ -789,6 +794,7 @@ def add_slaves(
             user=user,
             identity_file=identity_file,
             instance_type=ec2_instance_type,
+            block_duration_minutes=ec2_block_duration_minutes,
             num_slaves=num_slaves,
             assume_yes=assume_yes,
             **provider_options)


### PR DESCRIPTION
block duration spot 인스턴스를 지원하기 위한 커밋입니다.

on-demand로는 사용하기 아깝지만, 몇시간동안(6시간 이내) 인스턴스를 사용할 경우 시간을 지정하여 할경우 block duration spot instance를 사용하여 조금이라도 비용 절감을 할 수 있습니다.

또한, gurantee_num_instnace 파라미터를 추가할 경우 spot pool이나 spot price가 부족하여 instance가 뜨지 못하는 경우 open된 request를 삭제하고 추가하는 코드를 만들었습니다.
(하지만 코드 중복이 많아 개선을 하고 싶은데 명확한 아이디어가 떠오르지 않아 로직 구현만 하였습니다.)